### PR TITLE
Allow mtl 2.3.1

### DIFF
--- a/pipes-safe.cabal
+++ b/pipes-safe.cabal
@@ -39,7 +39,7 @@ Library
         base              >= 4.14    && < 4.17,
         containers        >= 0.6.2.1 && < 0.7 ,
         exceptions        >= 0.10.4  && < 0.11,
-        mtl               >= 2.2.2   && < 2.3 ,
+        mtl               >= 2.2.2   && < 2.4 ,
         transformers      >= 0.5.6.2 && < 0.6 ,
         transformers-base >= 0.4.4   && < 0.5 ,
         monad-control     >= 1.0.0.4 && < 1.1 ,


### PR DESCRIPTION
Tested with GHC 9.2.4 by running `for action in build test ; do cabal $action --enable-tests --constrain 'mtl == 2.3.1' || break ; done`.