### PR TITLE
Fixing the base bump for GHC 9.6.1 from #57

### DIFF
--- a/pipes-safe.cabal
+++ b/pipes-safe.cabal
@@ -36,7 +36,7 @@ Source-Repository head
 
 Library
     Build-Depends:
-        base              >= 4.14    && < 4.18,
+        base              >= 4.14    && < 4.19,
         containers        >= 0.6.2.1 && < 0.7 ,
         exceptions        >= 0.10.4  && < 0.11,
         mtl               >= 2.2.2   && < 2.4 ,


### PR DESCRIPTION
Struck down by my own hubris. Made a quick "on the web edit" of the base bounds for #57, and didn't notice the old base didn't even support GHC 9.4. GHC 9.6.1 uses base 4.18, so the edit to `< 4.18` was only sufficient to support GHC 9.4.

This time actually tested locally to support 9.6.1 and compile >.>