### PR TITLE
Allow transformers-0.6

### DIFF
--- a/pipes-safe.cabal
+++ b/pipes-safe.cabal
@@ -40,7 +40,7 @@ Library
         containers        >= 0.6.2.1 && < 0.7 ,
         exceptions        >= 0.10.4  && < 0.11,
         mtl               >= 2.2.2   && < 2.4 ,
-        transformers      >= 0.5.6.2 && < 0.6 ,
+        transformers      >= 0.5.6.2 && < 0.7 ,
         transformers-base >= 0.4.4   && < 0.5 ,
         monad-control     >= 1.0.0.4 && < 1.1 ,
         primitive         >= 0.7.0.0 && < 0.8 ,


### PR DESCRIPTION
Fixes #55.

Tested using `cabal build -w ghc-9.2.7 -c 'transformers>=0.6'`.
