### PR TITLE
Allow newer base and containers versions

### DIFF
--- a/pipes-safe.cabal
+++ b/pipes-safe.cabal
@@ -36,8 +36,8 @@ Source-Repository head
 
 Library
     Build-Depends:
-        base              >= 4.14    && < 4.19,
-        containers        >= 0.6.2.1 && < 0.7 ,
+        base              >= 4.14    && < 4.20,
+        containers        >= 0.6.2.1 && < 0.8 ,
         exceptions        >= 0.10.4  && < 0.11,
         mtl               >= 2.2.2   && < 2.4 ,
         transformers      >= 0.5.6.2 && < 0.7 ,


### PR DESCRIPTION
Fixes #66.

Tested using

```
cabal build -c 'containers>=0.7'
Build profile: -w ghc-9.8.1 -O1
```
